### PR TITLE
add andThen and orNull methods

### DIFF
--- a/src/Maybe.test.ts
+++ b/src/Maybe.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable array-callback-return */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Maybe } from "./Maybe";
 
 class A {}
@@ -371,6 +373,53 @@ describe("Maybe", () => {
           });
         });
       });
+    });
+  });
+
+  describe("orNull", () => {
+    it("should return the value when it exists", () => {
+      const value = "test" as const;
+      const result = Maybe.of(value).orNull();
+      expect(result).toEqual("test");
+    });
+
+    it("should return null when value is undefined", () => {
+      const result = Maybe.of(undefined).orNull();
+      expect(result).toEqual(null);
+    });
+
+    it("should return null when value is null", () => {
+      const result = Maybe.of(null).orNull();
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe("andThen", () => {
+    it("should transform value like map() when value exists", () => {
+      const value = "test" as const;
+      const result = Maybe.of(value)
+        .andThen((str) => str.length)
+        .getValue();
+      expect(result).toEqual(4);
+    });
+
+    it("should return Maybe with null when value is null", () => {
+      const a: string | null = null;
+      const result = Maybe.of(a)
+        .andThen((str: never) => {
+          return str;
+        })
+        .getValue();
+      expect(result).toEqual(null);
+    });
+
+    it("should chain multiple transformations", () => {
+      const value = "test" as const;
+      const result = Maybe.of(value)
+        .andThen((str) => str.length)
+        .andThen((len) => len * 2)
+        .getValue();
+      expect(result).toEqual(8);
     });
   });
 });

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -86,6 +86,10 @@ export class Maybe<T> {
     return new Maybe<NonNullable<R>>(null);
   }
 
+  andThen<R>(mapper: (value: NonNullable<T>) => R): Maybe<NonNullable<R>> {
+    return this.map(mapper);
+  }
+
   // NOTE: flatMap() "eats" the incomming maybe and will use the value of the current maybe as default
   // of the maybe returned by the Mapper()
   // you can safely use Maybies in the flatMap() function return value as if it was a direct value
@@ -107,6 +111,10 @@ export class Maybe<T> {
     }
 
     return new Maybe<U>(null) as LocalReturn;
+  }
+
+  orNull(): T | null {
+    return this.value ?? null;
   }
 
   getValue(): T | null | undefined;


### PR DESCRIPTION
- adds andThen method as an alias to map() - so that react eslint won't be confused
- adds orNull() "and" method that gets the value and defaults to null always, also useful in react